### PR TITLE
add osmosis and crescent chain params to classic

### DIFF
--- a/chains/classic/crescent.js
+++ b/chains/classic/crescent.js
@@ -1,0 +1,16 @@
+module.exports = {
+  chainID: 'crescent-1',
+  lcd: 'https://mainnet.crescent.network:1317',
+  gasAdjustment: 1.75,
+  gasPrices: { ucre: 0.01 },
+  prefix: 'cre',
+  coinType: '118',
+  baseAsset: 'ucre',
+  name: 'Crescent',
+  icon: 'https://station-assets.terra.money/img/chains/Crescent.svg',
+  ibc: {
+    fromTerra: 'channel-49',
+    toTerra: 'channel-0',
+  },
+  isClassic: true,
+}

--- a/chains/classic/osmosis.js
+++ b/chains/classic/osmosis.js
@@ -1,0 +1,16 @@
+module.exports = {
+  chainID: 'osmosis-1',
+  lcd: 'https://osmosis.feather.network',
+  gasAdjustment: 1.75,
+  gasPrices: { uosmo: 0.025 },
+  prefix: 'osmo',
+  coinType: '118',
+  baseAsset: 'uosmo',
+  name: 'Osmosis',
+  icon: 'https://station-assets.terra.money/img/chains/Osmosis.svg',
+  ibc: {
+    toTerra: 'channel-72',
+    fromTerra: 'channel-1',
+  },
+  isClassic: true,
+}


### PR DESCRIPTION
Is was not sure whether I had to provide the "isClassic" flag on the networks I added.

The chains which I added are basically the intersection set the set of assets that are available in the mainnet subfolder vs. the set of chains which are connected to Terra Classic via IBC.