### PR TITLE
fix 404 error on sei testnet

### DIFF
--- a/chains/testnet/sei.js
+++ b/chains/testnet/sei.js
@@ -1,6 +1,6 @@
 module.exports = {
   chainID: 'atlantic-1',
-  lcd: 'https://sei-testnet-rpc.polkachu.com',
+  lcd: 'https://sei-testnet-api.polkachu.com',
   gasAdjustment: 2,
   gasPrices: { usei: 0.01 },
   prefix: 'sei',


### PR DESCRIPTION
station-asset config key of sei.js points to a rpc server, but actually should be an lcd /rest server.