### PR TITLE
Use chainID in the token unique key

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -45,9 +45,9 @@ const axelar = require('./axelar.js')
   })
 
   // convert coins to json
-  const coinsOutPath = './build/denoms.json'
+  const coinsOutPath = './build/coins.json'
   const coinsOut = {}
-  const ibcDenomMapOutPath = './build/ibc.json'
+  const ibcDenomMapOutPath = './build/ibc_denoms.json'
   const ibcDenomMapOut = {}
 
   tokens.forEach((token) => {
@@ -60,15 +60,13 @@ const axelar = require('./axelar.js')
       ibcDenomMapOut[network] = {}
     }
 
-    const tokenId = [chainID, coinData.token].join(':')
-
-    coinsOut[network][tokenId] = { ...coinData, chains: [ chainID ] }
+    coinsOut[network][coinData.token] = { ...coinData, chains: [ chainID ] }
 
     if (coinData.isAxelar) {
       axelar[network].forEach((axelarChain) => {
         const ibcDenom = calculateIBCDenom(axelarChain.toAxelar, coinData.token)
         ibcDenomMapOut[network][ibcDenom] = {
-          token: tokenId,
+          token: coinData.token,
           chainID: axelarChain.chainID,
         }
       })
@@ -89,7 +87,7 @@ const axelar = require('./axelar.js')
         const nonHashedDenom = `transfer/${channel}/${coinData.token}`
 
         ibcDenomMapOut[network][ibcDenomOnTerra] = {
-          token: tokenId,
+          token: coinData.token,
           chainID: Object.values(chains[network]).find(
             ({ prefix }) => prefix === 'terra'
           ).chainID,
@@ -102,7 +100,7 @@ const axelar = require('./axelar.js')
           const channel = chains[network][chainID2].ibc.toTerra
           const ibcDenomOnOther = calculateIBCDenom(channel, nonHashedDenom)
           ibcDenomMapOut[network][ibcDenomOnOther] = {
-            token: tokenId,
+            token: coinData.token,
             chainID: chainID2,
           }
         })
@@ -113,7 +111,7 @@ const axelar = require('./axelar.js')
         const nonHashedDenom = `transfer/${channel}/${denom}`
 
         ibcDenomMapOut[network][ibcDenomOnTerra] = {
-          token: tokenId,
+          token: coinData.token,
           chainID: Object.values(chains[network]).find(
             ({ prefix }) => prefix === 'terra'
           ).chainID,
@@ -127,7 +125,7 @@ const axelar = require('./axelar.js')
           const channel = chains[network][chainID2].ibc.toTerra
           const ibcDenomOnOther = calculateIBCDenom(channel, nonHashedDenom)
           ibcDenomMapOut[network][ibcDenomOnOther] = {
-            token: tokenId,
+            token: coinData.token,
             chainID: chainID2,
           }
         })
@@ -142,7 +140,7 @@ const axelar = require('./axelar.js')
               coinData.token
             )
             ibcDenomMapOut[network][ibcDenomOnOther] = {
-              token: tokenId,
+              token: coinData.token,
               chainID: chainID2,
             }
           })
@@ -158,7 +156,7 @@ const axelar = require('./axelar.js')
 
             const ibcDenomOnOther = calculateIBCDenom(channel, denom)
             ibcDenomMapOut[network][ibcDenomOnOther] = {
-              token: tokenId,
+              token: coinData.token,
               chainID: chainID2,
               icsChannel: channel,
             }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "🛰️ Assets for Station",
   "main": "index.js",
   "scripts": {
-    "build": "node index.js",
+    "build": "node legacy.js && node index.js",
     "prettier": "prettier --write './**/*.js'"
   },
   "repository": {


### PR DESCRIPTION
This PR will replace the following files:
- `coins.json` -> `denoms.json`
- `ibc_denoms.json` -> `ibc.json`

The new files will use the chainID and the token base denom as unique token key instead of just the token denom.
This allows different chains to have tokens with the same base denom (i.e. uusdc on axelar and noble).

The old files will continue to be generated by `legacy.js`.