### PR TITLE
Add carbon ICS channels

### DIFF
--- a/chains/mainnet/carbon.js
+++ b/chains/mainnet/carbon.js
@@ -12,6 +12,12 @@ module.exports = {
   ibc: {
     fromTerra: 'channel-36',
     toTerra: 'channel-12',
+    icsFromTerra: {
+      contract:
+        'terra1e0mrzy8077druuu42vs0hu7ugguade0cj65dgtauyaw4gsl4kv0qtdf2au',
+      toTerra: 'channel-16',
+      fromTerra: 'channel-41',
+    },
   },
   explorer: {
     address: 'https://scan.carbon.network/account/{}?net=main',


### PR DESCRIPTION
This is needed to show CW20 tokens correctly on Carbon (ie ampLuna).

Sources for the information:
- denomination of ampLuna used on Alliance: https://station.terra.money/proposal/carbon-1/301
- channel used by that IBC denom: https://query-api.carbon.network/ibc/apps/transfer/v1/denom_traces/62A3870B9804FC3A92EAAA1F0F3F07E089DBF76CC521466CA33F5AAA8AD42290
- ICS contract on that channel: https://query-api.carbon.network/ibc/core/channel/v1/channels/channel-16/ports/transfer