### PR TITLE
Updated channels for Kujira/Terra after IBC client is renewed

### DIFF
--- a/chains/mainnet/kujira.js
+++ b/chains/mainnet/kujira.js
@@ -29,8 +29,8 @@ module.exports = {
     icsFromTerra: {
       contract:
         'terra1e0mrzy8077druuu42vs0hu7ugguade0cj65dgtauyaw4gsl4kv0qtdf2au',
-      toTerra: 'channel-36',
-      fromTerra: 'channel-28',
+      toTerra: 'channel-43',
+      fromTerra: 'channel-34',
     },
   },
   alliance: true,


### PR DESCRIPTION
Community mentioned that Station was sending CW20 assets to Kujira using the wrong channels. This update will allow for assets sent to Kujira from Terra to be recognized as canonical