### PR TITLE
Updated ibc channels for neutron & sei

### DIFF
--- a/chains/mainnet/axelar.js
+++ b/chains/mainnet/axelar.js
@@ -24,6 +24,7 @@ module.exports = {
     'stride-1': 'channel-64',
     'pacific-1': 'channel-103',
     'archway-1': 'channel-111',
+    'neutron-1': 'channel-78',
   },
   explorer: {
     address: 'https://www.mintscan.io/axelar/account/{}',

--- a/chains/mainnet/cosmoshub.js
+++ b/chains/mainnet/cosmoshub.js
@@ -26,6 +26,7 @@ module.exports = {
     'archway-1': 'channel-623',
     'noble-1': 'channel-536',
     'stafihub-1': 'channel-369',
+    'neutron-1': 'channel-569',
   },
   explorer: {
     address: 'https://www.mintscan.io/cosmos/account/{}',

--- a/chains/mainnet/kujira.js
+++ b/chains/mainnet/kujira.js
@@ -47,6 +47,7 @@ module.exports = {
     'archway-1': 'channel-99',
     'noble-1': 'channel-62',
     'stafihub-1': 'channel-63',
+    'neutron-1': 'channel-75',
   },
   alliance: true,
   explorer: {

--- a/chains/mainnet/mars.js
+++ b/chains/mainnet/mars.js
@@ -19,6 +19,7 @@ module.exports = {
     'crescent-1': 'channel-5',
     'kaiyo-1': 'channel-0',
     'osmosis-1': 'channel-1',
+    'mars-1': 'channel-37',
   },
   explorer: {
     address: 'https://explorer.marsprotocol.io/accounts/{}',

--- a/chains/mainnet/mars.js
+++ b/chains/mainnet/mars.js
@@ -19,7 +19,7 @@ module.exports = {
     'crescent-1': 'channel-5',
     'kaiyo-1': 'channel-0',
     'osmosis-1': 'channel-1',
-    'mars-1': 'channel-37',
+    'neutron-1': 'channel-37',
   },
   explorer: {
     address: 'https://explorer.marsprotocol.io/accounts/{}',

--- a/chains/mainnet/neutron.js
+++ b/chains/mainnet/neutron.js
@@ -10,13 +10,14 @@ module.exports = {
     icon: process.env.CF_PAGES_URL + '/img/chains/Neutron.png',
     disabledModules: ['staking'],
     channels: {
-      'phoenix-1': 'channel-5',
       'osmosis-1': 'channel-10',
       'stride-1': 'channel-8',
+      'axelar-1': 'channel-2',
+      'cosmoshub-4': 'channel-1',
+      'mars-1': 'channel-16',
+      'kaiyo-1': 'channel-3',
     },
-    ibc: {
-      fromTerra: 'channel-167',
-      toTerra: 'channel-5',
+    icsChannels: {
     },
     explorer: {
       address: 'https://www.mintscan.io/neutron/account/{}',

--- a/chains/mainnet/neutron.js
+++ b/chains/mainnet/neutron.js
@@ -12,7 +12,7 @@ module.exports = {
     channels: {
       'osmosis-1': 'channel-10',
       'stride-1': 'channel-8',
-      'axelar-1': 'channel-2',
+      'axelar-dojo-1': 'channel-2',
       'cosmoshub-4': 'channel-1',
       'mars-1': 'channel-16',
       'kaiyo-1': 'channel-3',

--- a/chains/mainnet/osmosis.js
+++ b/chains/mainnet/osmosis.js
@@ -37,6 +37,7 @@ module.exports = {
     'archway-1': 'channel-1429',
     'neutron-1': 'channel-874',
     'noble-1': 'channel-750',
+    'pacific-1': 'channel-782',
   },
   explorer: {
     address: 'https://www.mintscan.io/osmosis/account/{}',

--- a/chains/mainnet/terra.js
+++ b/chains/mainnet/terra.js
@@ -25,7 +25,6 @@ module.exports = {
     'migaloo-1': 'channel-86',
     'osmosis-1': 'channel-1',
     'stride-1': 'channel-46',
-    'neutron-1': 'channel-167',
     'pacific-1': 'channel-158',
     'noble-1': 'channel-151',
     'stafihub-1': 'channel-204',


### PR DESCRIPTION
1. Removed Terra <> Neutron IBC channel as that's used specifically for CW20 transfers for ASTRO tokens from Terra <> Neutron. There currently isn't a channel open for native asset transfers between both chains
2. Added support for native transfers between Neutron and axelar-dojo-1, cosmoshub-4, mars-1, kaiyo-1